### PR TITLE
avoid warning

### DIFF
--- a/jni/QSEEComAPI.c
+++ b/jni/QSEEComAPI.c
@@ -1,6 +1,7 @@
 #include "QSEEComAPI.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include <dlfcn.h>
     
 struct qcom_wv_handle* initialize_wv_handle() {


### PR DESCRIPTION
on windows with ndk-r11c warning perror implict define
